### PR TITLE
Add support for keyboard via a `@useFocus` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Optional. The show delay will prevent the tooltip from being shown until the spe
 
 Optional. The hide delay will prevent the tooltip from being hidden until the specified milliseconds have passed after leaving the reference element.
 
+#### `@useFocus`
+
+Optional. By default, tooltips will only show when hovering over the reference element. Use this argument to also show the tooltip when the reference element is focused with keyboard.
+
 #### `@stickyID`
 
 Optional. You can group tooltips together with a sticky identifier. When a tooltip from a group of tooltips all with the same identifier is shown, then other tooltips in that group will show instantly - ignoring their show delay. The term sticky is used because it feels as if the tooltips are stuck open.
@@ -100,22 +104,21 @@ In the following example, there is a show delay of `300`ms before a tooltip will
 
 <details>
   <summary>Example</summary>
-  
+
 ```handlebars
 {{! application.gjs }}
 <LinkTo @route='user' @model={{123}}>
   Preview user
   <UserTooltip @id={{123}} />
 </LinkTo>
-
-````
+```
 
 ```handlebars
 {{! user-tooltip.gjs }}
 <Tooltip @showDelay={{300}} @onLoad={{fn this.loadUser @id}} as |tooltip|>
   {{tooltip.data.user.name}}
 </Tooltip>
-````
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Optional. The hide delay will prevent the tooltip from being hidden until the sp
 
 #### `@useFocus`
 
-Optional. By default, tooltips will only show when hovering over the reference element. Use this argument to also show the tooltip when the reference element is focused with keyboard.
+Optional. By default, tooltips will only show when hovering over the reference element. Use this argument to also show the tooltip when the reference element is focused.
 
 #### `@stickyID`
 

--- a/tests/dummy/app/controllers/manual.js
+++ b/tests/dummy/app/controllers/manual.js
@@ -6,12 +6,7 @@ export default class ManualPositioningController extends Controller {
   @tracked shouldShowTooltip;
 
   @action
-  showTooltip() {
-    this.shouldShowTooltip = true;
-  }
-
-  @action
-  hideTooltip() {
-    this.shouldShowTooltip = false;
+  toggleTooltip() {
+    this.shouldShowTooltip = !this.shouldShowTooltip;
   }
 }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -19,4 +19,5 @@ Router.map(function () {
   this.route('attach-to');
   this.route('sticky');
   this.route('tether');
+  this.route('use-focus');
 });

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -8,3 +8,4 @@
 @use 'tables';
 @use 'util';
 @use 'tether';
+@use 'use-focus';

--- a/tests/dummy/app/styles/use-focus.scss
+++ b/tests/dummy/app/styles/use-focus.scss
@@ -1,0 +1,5 @@
+.use-focus-page {
+  display: flex;
+  flex-direction: row;
+  gap: 14px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -76,6 +76,12 @@
   <LinkTo @route="tether">
     Tether
   </LinkTo>
+
+  |
+
+  <LinkTo @route="use-focus">
+    Use Focus
+  </LinkTo>
 </p>
 
 {{outlet}}

--- a/tests/dummy/app/templates/manual.hbs
+++ b/tests/dummy/app/templates/manual.hbs
@@ -3,13 +3,7 @@
 </p>
 
 <div>
-  <input
-    type="text"
-    placeholder="Focus me"
-    aria-label="Example text area"
-    {{on "focus" this.showTooltip}}
-    {{on "blur" this.hideTooltip}}
-  />
+  <button type="button" {{on "click" this.toggleTooltip}}>Toggle Tooltip</button>
 
   {{#if this.shouldShowTooltip}}
     <Tooltip @show={{true}}>

--- a/tests/dummy/app/templates/use-focus.hbs
+++ b/tests/dummy/app/templates/use-focus.hbs
@@ -1,0 +1,35 @@
+<p>
+  Use Focus (for keyboard support)
+</p>
+
+<div class="use-focus-page">
+  <button type="button">
+    I should show when focused with a keyboard
+
+    <Tooltip @useFocus={{true}}>
+      Hello World
+    </Tooltip>
+  </button>
+
+  <div tabindex="0">
+    Focus me (I have interactive children)
+    <Tooltip @useFocus={{true}}>
+      Hello
+      <a href="#">World</a>
+    </Tooltip>
+  </div>
+
+  <button type="button">
+    I should
+    <i>not</i>
+    show a tooltip when focused with a keyboard
+
+    <Tooltip @useFocus={{false}}>
+      Hello World
+    </Tooltip>
+  </button>
+</div>
+
+<div id="portal">
+  {{! tooltip rendered here }}
+</div>

--- a/tests/integration/components/tooltip/focus-events-test.gjs
+++ b/tests/integration/components/tooltip/focus-events-test.gjs
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { focus, render } from '@ember/test-helpers';
+import { focus, render, blur } from '@ember/test-helpers';
 import Tooltip from '@zestia/ember-async-tooltips/components/tooltip';
 
 module('tooltip | focus', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('focusing', async function (assert) {
+  test('focusing (default)', async function (assert) {
     assert.expect(1);
 
     await render(<template>
@@ -23,5 +23,81 @@ module('tooltip | focus', function (hooks) {
       though many browsers will display it on touch
       `
     );
+  });
+
+  test('focusing (@useFocus)', async function (assert) {
+    assert.expect(2);
+
+    await render(<template>
+      <a href="#">
+        <Tooltip @useFocus={{true}} />
+      </a>
+    </template>);
+
+    await focus('.tooltipper');
+
+    assert.dom('.tooltip').exists(
+      `
+      tooltips are displayed when focus enters a reference element if @useFocus is true.
+      `
+    );
+
+    await blur('.tooltipper');
+
+    assert.dom('.tooltip').doesNotExist();
+  });
+
+  test('focusing a tooltip with interactive children', async function (assert) {
+    assert.expect(3);
+
+    await render(<template>
+      <div class="tooltipper" tabindex="0">
+        <Tooltip @useFocus={{true}}>
+          Hello
+          <a href="#">World</a>
+        </Tooltip>
+      </div>
+    </template>);
+
+    assert.dom('.tooltip').doesNotExist();
+
+    await focus('.tooltipper');
+
+    assert.dom('.tooltip').exists();
+
+    await focus('.tooltip a');
+
+    assert
+      .dom('.tooltip')
+      .exists('it does not hide the tooltip when focusing within the tooltip');
+  });
+
+  test('focusing a tooltip with interactive children (rendered in a different output destination)', async function (assert) {
+    assert.expect(3);
+
+    await render(<template>
+      <div class="tooltipper" tabindex="0">
+        <Tooltip @useFocus={{true}} @destination={{"#portal"}}>
+          Hello
+          <a href="#">World</a>
+        </Tooltip>
+      </div>
+
+      <div id="portal">
+        {{! tooltip rendered here }}
+      </div>
+    </template>);
+
+    assert.dom('.tooltip').doesNotExist();
+
+    await focus('.tooltipper');
+
+    assert.dom('.tooltip').exists();
+
+    await focus('.tooltip a');
+
+    assert
+      .dom('.tooltip')
+      .exists('it does not hide the tooltip when focusing within the tooltip');
   });
 });

--- a/tests/integration/components/tooltip/focus-events-test.gjs
+++ b/tests/integration/components/tooltip/focus-events-test.gjs
@@ -77,7 +77,7 @@ module('tooltip | focus', function (hooks) {
 
     await render(<template>
       <div class="tooltipper" tabindex="0">
-        <Tooltip @useFocus={{true}} @destination={{"#portal"}}>
+        <Tooltip @useFocus={{true}} @destination="#portal">
           Hello
           <a href="#">World</a>
         </Tooltip>

--- a/tests/integration/components/tooltip/loading-data-test.gjs
+++ b/tests/integration/components/tooltip/loading-data-test.gjs
@@ -1,6 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, waitUntil, settled, triggerEvent } from '@ember/test-helpers';
+import {
+  render,
+  waitUntil,
+  settled,
+  triggerEvent,
+  focus
+} from '@ember/test-helpers';
 import {
   wait,
   hasText,
@@ -84,6 +90,45 @@ module('tooltip | loading data', function (hooks) {
 
     triggerEvent('.tooltipper', 'mouseenter');
     triggerEvent('.tooltipper', 'mouseleave');
+
+    await settled();
+
+    assert.verifySteps(['loading data']);
+
+    assert.dom('.tooltip').doesNotExist();
+  });
+
+  test('focus / loading data', async function (assert) {
+    assert.expect(3);
+
+    const load = () => assert.step('loading data');
+
+    await render(<template>
+      <button type="button">
+        <Tooltip @onLoad={{load}} @useFocus={{true}} />
+      </button>
+    </template>);
+
+    await focus('.tooltipper');
+
+    assert.verifySteps(['loading data']);
+
+    assert.dom('.tooltip').exists();
+  });
+
+  test('blur / loading data', async function (assert) {
+    assert.expect(3);
+
+    const load = () => assert.step('loading data');
+
+    await render(<template>
+      <button type="button">
+        <Tooltip @onLoad={{load}} @useFocus={{true}} />
+      </button>
+    </template>);
+
+    triggerEvent('.tooltipper', 'focus');
+    triggerEvent('.tooltipper', 'blur');
 
     await settled();
 

--- a/tests/integration/components/tooltip/manually-showing-hiding-test.gjs
+++ b/tests/integration/components/tooltip/manually-showing-hiding-test.gjs
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, settled } from '@ember/test-helpers';
+import { render, settled, click, triggerEvent } from '@ember/test-helpers';
+import { on } from '@ember/modifier';
 import { tracked } from '@glimmer/tracking';
 import Tooltip from '@zestia/ember-async-tooltips/components/tooltip';
 
@@ -33,5 +34,59 @@ module('tooltip | manual', function (hooks) {
     await settled();
 
     assert.dom('.tooltip').doesNotExist();
+  });
+
+  test('mouse/keyboard events do not effect tooltip when manually showing / hiding', async function (assert) {
+    assert.expect(6);
+
+    const state = new (class {
+      @tracked show;
+    })();
+
+    const toggleTooltip = () => {
+      state.show = !state.show;
+    };
+
+    await render(<template>
+      <button
+        type="button"
+        class="tooltipper-element"
+        {{on "click" toggleTooltip}}
+      >
+        <Tooltip @show={{state.show}} />
+      </button>
+    </template>);
+
+    assert.dom('.tooltip').doesNotExist();
+
+    await triggerEvent('.tooltipper-element', 'mouseenter');
+    await click('.tooltipper-element');
+
+    assert.dom('.tooltip').exists();
+
+    await triggerEvent('.tooltipper-element', 'mouseleave');
+
+    assert
+      .dom('.tooltip')
+      .exists(
+        'it still shows the tooltip despite the mouse leaving the tooltipper as we are manually showing and hiding'
+      );
+
+    await click('.tooltipper-element');
+
+    assert.dom('.tooltip').doesNotExist();
+
+    await triggerEvent('.tooltipper-element', 'focus');
+    await click('.tooltipper-element');
+
+    assert.dom('.tooltip').exists();
+
+    await triggerEvent('.tooltipper-element', 'blur');
+
+    assert
+      .dom('.tooltip')
+      .exists(
+        'it still shows the tooltip despite the blur event as we are manually showing and hiding'
+      );
   });
 });


### PR DESCRIPTION
Adds a `@useFocus` argument to the tooltip component (off by default) to allow showing the tooltip when a user focuses the tooltipper instead of this only being available to mouse users.

Previously this would be handled in the code of an app that uses the addon by wrapping the tooltip and manually showing/hiding it based on focus/blur events.

Added tests around the `show` arg as I accidentally broke this behaviour but tests didn't catch it.

### Areas for review

General thoughts +

* Does it make sense to combine the event listeners for mouse/keyboard? (ie. just use a single handler and `isOverTooltipper` variable), and then whether or not keyboard is supported would be handled purely by whether or not the event listeners have been added or not

* Have I missed any places worth testing?