### PR TITLE
Hide tooltips on `mouseleave` when `@useFocus` is true

### DIFF
--- a/src/components/tooltip.gjs
+++ b/src/components/tooltip.gjs
@@ -194,6 +194,7 @@ export default class TooltipComponent extends Component {
 
   handleMouseLeaveTooltipperElement = () => {
     this.isOverTooltipperElement = false;
+    this.tooltipperElementIsFocused = false;
     this.#scheduleHideTooltip();
   };
 

--- a/tests/integration/focus-events-test.gjs
+++ b/tests/integration/focus-events-test.gjs
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { focus, render, blur } from '@ember/test-helpers';
+import { focus, render, blur, click, triggerEvent } from '@ember/test-helpers';
 import Tooltip from '@zestia/ember-async-tooltips/components/tooltip';
 
 module('tooltip | focus', function (hooks) {
@@ -51,7 +51,7 @@ module('tooltip | focus', function (hooks) {
     assert.dom('.tooltip').doesNotExist();
   });
 
-  test('focusing a tooltip with interactive children', async function (assert) {
+  test('focusing a tooltip with interactive children (@useFocus)', async function (assert) {
     assert.expect(3);
 
     await render(
@@ -78,7 +78,7 @@ module('tooltip | focus', function (hooks) {
       .exists('it does not hide the tooltip when focusing within the tooltip');
   });
 
-  test('focusing a tooltip with interactive children (rendered in a different output destination)', async function (assert) {
+  test('focusing a tooltip with interactive children rendered in a different output destination (@useFocus)', async function (assert) {
     assert.expect(3);
 
     await render(
@@ -107,5 +107,70 @@ module('tooltip | focus', function (hooks) {
     assert
       .dom('.tooltip')
       .exists('it does not hide the tooltip when focusing within the tooltip');
+  });
+
+  test('focusing by clicking (@useFocus)', async function (assert) {
+    assert.expect(3);
+
+    await render(
+      <template>
+        <button type="button">
+          <Tooltip @useFocus={{true}} />
+        </button>
+      </template>
+    );
+
+    await click('.tooltipper');
+
+    assert.dom('.tooltip').exists(
+      `
+      tooltips are displayed when element is focused/hovered
+      `
+    );
+
+    await triggerEvent('.tooltipper', 'mouseleave');
+
+    assert.dom('.tooltipper').isFocused();
+
+    assert
+      .dom('.tooltip')
+      .doesNotExist(
+        'it hides the tooltip when the mouse leaves the reference element, even if the reference element is still focused and @useFocus is true'
+      );
+  });
+
+  test('focusing a tooltip that has interactive children by clicking (@useFocus)', async function (assert) {
+    assert.expect(4);
+
+    await render(
+      <template>
+        <button type="button">
+          <Tooltip @useFocus={{true}}>
+            Hello
+            <a href="#">World</a>
+          </Tooltip>
+        </button>
+      </template>
+    );
+
+    assert.dom('.tooltip').doesNotExist();
+
+    await click('.tooltipper');
+
+    assert.dom('.tooltip').exists();
+
+    await focus('.tooltip a');
+
+    assert
+      .dom('.tooltip')
+      .exists('it does not hide the tooltip when focusing within the tooltip');
+
+    await triggerEvent('.tooltipper', 'mouseleave');
+
+    assert
+      .dom('.tooltip')
+      .exists(
+        'it does not hide the tooltip when the mouse leaves the reference element, if the interactive content inside of the tooltip has focus'
+      );
   });
 });


### PR DESCRIPTION
If a user clicks a tooltipper, which means it gains focus, the tooltip would not have been hidden when they move their mouse away if `@useFocus` is true as the tooltipper would still have focus from the click. If using a mouse you don't really care about whether an element is focused or not.

Added a test for this behaviour, and a test to make sure that the tooltips aren't hidden on `mouseleave` when you're focused on their interactive children. 