### PR TITLE
Explore a `<DisabledWrapper>` component

### DIFF
--- a/demo-app/app.gts
+++ b/demo-app/app.gts
@@ -21,6 +21,7 @@ Router.map(function () {
   this.route('tether');
   this.route('use-click');
   this.route('use-focus');
+  this.route('disabled-button');
 });
 
 export class App extends EmberApp {

--- a/demo-app/templates/application.gjs
+++ b/demo-app/templates/application.gjs
@@ -84,6 +84,12 @@ export default Route(
       <LinkTo @route="use-focus">
         Use Focus
       </LinkTo>
+
+      |
+
+      <LinkTo @route="disabled-button">
+        Disabled button
+      </LinkTo>
     </p>
 
     {{outlet}}

--- a/demo-app/templates/disabled-button.gjs
+++ b/demo-app/templates/disabled-button.gjs
@@ -1,0 +1,77 @@
+import Route from 'ember-route-template';
+import Tooltip from '@zestia/ember-async-tooltips/components/tooltip';
+import DisabledWrapper from '@zestia/ember-async-tooltips/components/disabled-wrapper';
+
+export default Route(
+  <template>
+    <p>
+      Disabled buttons cannot receive focus (or mouseenter if in a test suite),
+      so a tooltip on the button itself never shows unless you use a wrapper
+      element.
+    </p>
+
+    <h2>
+      Tooltip on a disabled button without a wrapper
+    </h2>
+
+    <p>
+      This disabled button has the tooltip on itself. You cannot focus a
+      disabled button, so the tooltip never appears.
+    </p>
+
+    <button type="button" disabled>
+      I am disabled
+
+      <Tooltip @useFocus={{true}}>
+        You will never see this — disabled elements can't receive focus
+      </Tooltip>
+    </button>
+
+    <br /><br />
+
+    <h2>
+      Tooltip on a disabled button wrapped with the
+      <code>&lt;DisabledWrapper&gt;</code>
+      component
+    </h2>
+
+    <p>
+      Put the tooltip on a wrapper element that is focusable when the button
+      inside is disabled. When the button is disabled, the wrapper will receive
+      focus and the tooltip will be shown.
+    </p>
+
+    <DisabledWrapper @disabled={{true}} @role="button">
+      <button type="button" disabled>
+        I am disabled
+      </button>
+
+      <Tooltip @useFocus={{true}}>
+        Button is disabled. This tooltip is on the wrapper.
+      </Tooltip>
+    </DisabledWrapper>
+
+    <br /><br />
+
+    <h2>
+      Tooltip on an enabled button wrapped with the
+      <code>&lt;DisabledWrapper&gt;</code>
+      component
+    </h2>
+
+    <p>
+      The tooltip shows when the button is focused, despite the wrapper being
+      the tooltipper.
+    </p>
+
+    <DisabledWrapper @disabled={{false}} @role="button">
+      <button type="button">
+        I am not disabled
+      </button>
+
+      <Tooltip @useFocus={{true}}>
+        This tooltip should show when the button is focused
+      </Tooltip>
+    </DisabledWrapper>
+  </template>
+);

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "ember-addon": {
     "app-js": {
       "./components/tooltip.js": "./dist/_app_/components/tooltip.js",
+      "./components/disabled-wrapper.js": "./dist/_app_/components/disabled-wrapper.js",
       "./services/tooltip.js": "./dist/_app_/services/tooltip.js"
     },
     "main": "addon-main.cjs",

--- a/src/components/disabled-wrapper.gjs
+++ b/src/components/disabled-wrapper.gjs
@@ -1,0 +1,20 @@
+/**
+ * When a direct child (e.g. a button) is disabled, that element cannot receive
+ * focus, so a tooltip on the child never shows. This wrapper becomes
+ * the focusable "stand-in" when disabled: it gets a tabindex, role,
+ * and aria attributes so the tooltip can be shown on the wrapper.
+ *
+ * When not disabled, the wrapper is a plain div with no extra attributes so
+ * keyboard users tab directly to the real control.
+ */
+
+<template>
+  <div
+    tabindex={{if @disabled "0"}}
+    role={{if @disabled @role}}
+    aria-disabled={{if @disabled "true"}}
+    ...attributes
+  >
+    {{yield}}
+  </div>
+</template>

--- a/src/components/tooltip.gjs
+++ b/src/components/tooltip.gjs
@@ -483,8 +483,8 @@ export default class TooltipComponent extends Component {
       }
 
       if (this.args.useFocus) {
-        this.#add(el, 'focus', this.handleFocusTooltipperElement);
-        this.#add(el, 'blur', this.handleBlurTooltipperElement);
+        this.#add(el, 'focusin', this.handleFocusTooltipperElement);
+        this.#add(el, 'focusout', this.handleBlurTooltipperElement);
       }
     }
 
@@ -499,8 +499,8 @@ export default class TooltipComponent extends Component {
         }
 
         if (this.args.useFocus) {
-          this.#rem(el, 'focus', this.handleFocusTooltipperElement);
-          this.#rem(el, 'blur', this.handleBlurTooltipperElement);
+          this.#rem(el, 'focusin', this.handleFocusTooltipperElement);
+          this.#rem(el, 'focusout', this.handleBlurTooltipperElement);
         }
       }
     };

--- a/tests/integration/loading-data-test.gjs
+++ b/tests/integration/loading-data-test.gjs
@@ -120,7 +120,7 @@ module('tooltip | loading data', function (hooks) {
     assert.dom('.tooltip').exists();
   });
 
-  test('blur / loading data', async function (assert) {
+  test('focusout / loading data', async function (assert) {
     assert.expect(3);
 
     const load = () => assert.step('loading data');
@@ -133,8 +133,9 @@ module('tooltip | loading data', function (hooks) {
       </template>
     );
 
-    triggerEvent('.tooltipper', 'focus');
-    triggerEvent('.tooltipper', 'blur');
+    focus('.tooltipper');
+
+    triggerEvent('.tooltipper', 'focusout');
 
     await settled();
 


### PR DESCRIPTION
If your tooltipper is a disabled element, the tooltip will not show for keyboard users (as you can't focus a disabled element), or in a test suite with simulated `mouseenter` events for the same reason.

This PR explores the addition of a `<DisabledWrapper>` component that provides a wrapper acting as a fake element that is focusable. In this scenario the wrapper is the tooltipper, not the disabled element. When the element is _not_ disabled, then the wrapper just acts as an empty `div`.

Note that I've had to adjust the focus events to check for `focusin` and `focusout` as if a button is _not_ disabled, but is wrapped with `<DisabledWrapper>`, we don't want to force the user to have to tab twice to get to the button, this change means the wrapper will remain the tooltipper, just not focusable, instead reacting to the bubbling focus event from the button. I'm not too sure on whether this is the right approach, or if there are any knock on effects 🤔 

Note that there are no tests for this functionality yet. This is just exploring it.